### PR TITLE
Fix return false when $this->agent is empty.

### DIFF
--- a/Metadata/Metadata.php
+++ b/Metadata/Metadata.php
@@ -113,7 +113,8 @@ class Metadata implements MetadataInterface
      */
     public function match($agent, $ip)
     {
-        if ((self::AGENT_MATCH_EXACT === $this->agentMatch && $this->agent !== $agent) ||
+        if (!$this->agent ||
+            (self::AGENT_MATCH_EXACT === $this->agentMatch && $this->agent !== $agent) ||
             (self::AGENT_MATCH_REGEXP === $this->agentMatch && !@preg_match('#' . $this->agent . '#', $agent))) {
             return false;
         }
@@ -121,7 +122,7 @@ class Metadata implements MetadataInterface
         if (is_null($this->ip)) {
             return true;
         }
-        
+
         if (is_array($this->ip)) {
             return in_array($ip, $this->ip);
         }


### PR DESCRIPTION
When $this->agent is empty, AboutUs robot is identified because the condition's agent and ip are empty.
