### PR TITLE
Simplifies YAML file loading

### DIFF
--- a/Metadata/Loader/YamlFileLoader.php
+++ b/Metadata/Loader/YamlFileLoader.php
@@ -27,7 +27,7 @@ class YamlFileLoader extends FileLoader
      */
     public function load($file, $type = null)
     {
-        $file = $this->locator->locate($file);
+        $file = $this->locator->locate($file, __DIR__.'/../../Resources/metadata');
         $collection = new MetadataCollection();
 
         $collection->addResource(new FileResource($file));

--- a/Tests/Metadata/Loader/YamlFileLoaderTest.php
+++ b/Tests/Metadata/Loader/YamlFileLoaderTest.php
@@ -31,9 +31,9 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
     {
         $locator = new FileLocator();
         $loader = new YamlFileLoader($locator);
-
-        $metadatasAbsolute  = $loader->load( __DIR__ . '/../../../Resources/metadata/extended.yml' )->getMetadatas();
-        $metadatasEasy = $loader->load( 'extended.yml' )->getMetadatas();
+        
+        $metadatasAbsolute  = $loader->load(__DIR__ . '/../../../Resources/metadata/extended.yml')->getMetadatas();
+        $metadatasEasy = $loader->load('extended.yml')->getMetadatas();
 
         $this->assertEquals($metadatasAbsolute, $metadatasEasy);
     }

--- a/Tests/Metadata/Loader/YamlFileLoaderTest.php
+++ b/Tests/Metadata/Loader/YamlFileLoaderTest.php
@@ -27,6 +27,17 @@ class YamlFileLoaderTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($loader->supports('test.xml'));
     }
 
+    public function testEasyLoaderPath()
+    {
+        $locator = new FileLocator();
+        $loader = new YamlFileLoader($locator);
+
+        $metadatasAbsolute  = $loader->load( __DIR__ . '/../../../Resources/metadata/extended.yml' )->getMetadatas();
+        $metadatasEasy = $loader->load( 'extended.yml' )->getMetadatas();
+
+        $this->assertEquals($metadatasAbsolute, $metadatasEasy);
+    }
+
     public function testParsing()
     {
         $locator = new FileLocator();


### PR DESCRIPTION
Issue #19 &middot; Updates the `YamlFileLoader` loader to read from `/Resources/metadata/` by default, simplifying usability. An absolute path can still be passed to override the default behavior.

```php
# Instantiate a BotDetector with the YamlFileLoader instance and path to YAML.
$detector = new Vipx\BotDetect\BotDetector($loader, 'extended.yml');

```

**NOTE:** This is my second pull request due to complications with the GitHub desktop application. This request has the test cases as requested.