### PR TITLE
Change regexp to strpos for speed optimization

### DIFF
--- a/Metadata/Metadata.php
+++ b/Metadata/Metadata.php
@@ -114,7 +114,7 @@ class Metadata implements MetadataInterface
     public function match($agent, $ip)
     {
         if ((self::AGENT_MATCH_EXACT === $this->agentMatch && $this->agent !== $agent) ||
-            (self::AGENT_MATCH_REGEXP === $this->agentMatch && !@preg_match('#' . $this->agent . '#', $agent))) {
+            (self::AGENT_MATCH_REGEXP === $this->agentMatch && strpos($agent, $this->agent)===false)) {
             return false;
         }
 


### PR DESCRIPTION
When checking the source code of matching user agents to bots I noticed that a preg_match is being used - this is unnecessary and in my opinion dangerous for multiple reasons:

- No regular expressions are actually used in the yml files to match bots/crawlers etc. as far as I can tell
- Special regexp characters are used in some of the agents, like "heritrix/1." or "http://www.WISEnutbot.com". The dots match any character, and it is easy to accidentally include regex characters and corrupt the bot matching, or to actually make the regex invalid
- strpos is much faster than preg_match, and less complex

With my pull request the preg_match is replaced by strpos - I think everything should still work the same with this change, just faster and less error prone.