### PR TITLE
Add Travis configuration for testing with Symfony 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
     - php: 7
       env: SYMFONY_VERSION=3.0.*@dev
 
-before_script:
+before_install:
   - composer self-update
   - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,27 @@ php:
   - 7
   - hhvm
 
+cache:
+  directories:
+    - $HOME/.composer/cache/files
+
+env:
+  - SYMFONY_VERSION=2.3.*
+
 matrix:
   allow_failures:
     - php: 7
+  include:
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*@dev
+    - php: 7
+      env: SYMFONY_VERSION=3.0.*@dev
 
 before_script:
-  - wget http://getcomposer.org/composer.phar
-  - php composer.phar install --dev --prefer-source --no-interaction
+  - composer self-update
+  - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
+
+install: composer update --prefer-source
 
 script:
   - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,14 @@ php:
   - 7
   - hhvm
 
+sudo: false
+
 cache:
   directories:
     - $HOME/.composer/cache/files
 
 env:
-  - SYMFONY_VERSION=2.3.*
+  - SYMFONY_VERSION=2.7.*
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -28,10 +28,5 @@
         "branch-alias": {
             "dev-master": "1.2.x-dev"
         }
-    },
-    "config": {
-        "platform": {
-            "php": "5.4"
-        }
     }
 }


### PR DESCRIPTION
This PR will have failing tests due to a bug when `vipx-bot-detect` is used with Symfony in version 3.

See #38.