### PR TITLE
Switch from testing `__toString` and `getPath` method

### DIFF
--- a/BotDetector.php
+++ b/BotDetector.php
@@ -89,8 +89,8 @@ class BotDetector implements BotDetectorInterface
         $cache = new ConfigCache($this->options['cache_dir'] . '/' . $this->options['metadata_cache_file'], $this->options['debug']);
 
         if ($cache->isFresh()) {
-            if (method_exists($cache, '__toString')) {
-                // ConfigCache Symfony < 3.0 syntax.
+            if (!method_exists($cache, 'getPath')) {
+                // ConfigCache Symfony < 2.7 syntax.
                 return $this->metadatas = require $cache;
             }
 


### PR DESCRIPTION
This way, you do not throw a `DEPRECATED` call and symfony 2.7+ use the non-deprecated `getPath` call